### PR TITLE
fix: read OpenAPI parameter type from nested schema

### DIFF
--- a/api_foundry/utils/model_factory.py
+++ b/api_foundry/utils/model_factory.py
@@ -677,8 +677,15 @@ class PathOperation(OpenAPIElement):
                 properties[name] = SchemaObjectProperty(self.entity, name, prop_schema)
         elif section == "parameters":
             for param in path_operation.get("parameters", {}) or []:
+                # OpenAPI parameter objects nest type/default/etc. under
+                # `schema` (unlike requestBody/responses properties, which
+                # are already flat) -- merge schema over the parameter
+                # object so type/default/minLength/etc. are read from the
+                # right place while still keeping parameter-level fields
+                # like `required` and `description`.
+                merged = {**param, **(param.get("schema") or {})}
                 properties[param["name"]] = SchemaObjectProperty(
-                    self.entity, param["name"], param
+                    self.entity, param["name"], merged
                 )
         elif section == "responses":
             responses = path_operation.get("responses", {})

--- a/tests/test_model_factory.py
+++ b/tests/test_model_factory.py
@@ -372,9 +372,12 @@ def test_path_operation_parsing():
     assert op["action"] == "read"
     # inputs
     assert set(op["inputs"].keys()) == {"limit", "q"}
-    # ModelFactory currently treats parameter types as string
-    # unless top-level 'type' is present
-    assert op["inputs"]["limit"]["api_type"] == "string"
+    # Parameter objects nest type/default/etc. under `schema` per the
+    # OpenAPI spec (unlike requestBody/responses properties, which are
+    # already flat) -- this must be read from there, not a nonexistent
+    # top-level 'type' on the parameter object.
+    assert op["inputs"]["limit"]["api_type"] == "integer"
+    assert op["inputs"]["q"]["api_type"] == "string"
     # outputs
     assert set(op["outputs"].keys()) == {"id", "name"}
     assert op["outputs"]["id"]["api_type"] == "string"


### PR DESCRIPTION
## Summary
- `PathOperation` was passing raw OpenAPI path/query parameter objects straight to `SchemaObjectProperty`. Per the OpenAPI spec, parameter objects nest `type`/`default`/`minLength`/etc. under a `schema` key (unlike `requestBody`/response properties, which are already flat) — so every parameter was silently resolving to `api_type: "string"` regardless of its declared type.
- Fix merges `schema` over the parameter object before constructing `SchemaObjectProperty`, so schema fields (type, default, etc.) are read from the right place while parameter-level fields (`required`, `description`) are preserved.
- `test_path_operation_parsing` updated to assert the correct type for both an integer parameter (`limit`) and a string parameter (`q`), replacing the old assertion that documented the buggy string-only behavior.

## Test plan
- [x] `pytest tests/test_model_factory.py` — 15/17 passing, same 2 pre-existing failures (`test_sequence_primary_key_requires_sequence_name`, `test_chinook_generation` — unrelated `ApplicationException` on a Chinook fixture's duplicate primary keys) reproduced identically on `main` before this change, confirming no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)